### PR TITLE
Change .fecov to remove multiple unnecessary calls to summary.lm.

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -5,7 +5,7 @@ require(strucchange)
 ##
 ".fecov" <-
 function(x, n.ahead) {
-  n.par<-sapply(x$varresult, function(x) summary(x)$df[2])
+  n.par <- sapply(x$varresult, function (res) x$obs - length(res$coefficients))
   sigma.u <- crossprod(resid(x))/n.par
   Sigma.yh <- array(NA, dim = c(x$K, x$K, n.ahead))
   Sigma.yh[, , 1] <- sigma.u


### PR DESCRIPTION
The function summary.lm is rather complex, and there is no need to call it when we just require the degrees of freedom. This change removes that call and saves some computational complexity.